### PR TITLE
Handle refresh page

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -8,6 +8,8 @@ import Footer from 'domain/layout/component/Footer';
 import { connect } from 'react-redux';
 import Auth from 'domain/user/component/Auth';
 import { githubStar } from 'infra/service/util';
+import groupRepo from 'infra/repo/group';
+import loc from 'infra/service/location';
 
 const mapStateToProps = state => ({
   profile: state.user.profile,
@@ -32,8 +34,14 @@ class App extends React.Component {
       .then(response => {
         this.setState({
           starCount: response.stargazers_count,
-        })
+        });
       })
+      .then(() => {
+        groupRepo.restoreGroup();
+      })
+      .then(() => {
+        loc.push('/metric/summary');
+      });
   }
 
   render() {

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -10,6 +10,7 @@ import Auth from 'domain/user/component/Auth';
 import { githubStar } from 'infra/service/util';
 import groupRepo from 'infra/repo/group';
 import loc from 'infra/service/location';
+import { syncToPromise } from 'infra/service/util';
 
 const mapStateToProps = state => ({
   profile: state.user.profile,
@@ -36,7 +37,7 @@ class App extends React.Component {
           starCount: response.stargazers_count,
         });
       })
-      .then(() => {
+      .then(() => syncToPromise(() => {
         groupRepo.restoreGroup();
       })
       .then(() => {

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -39,7 +39,7 @@ class App extends React.Component {
       })
       .then(() => syncToPromise(() => {
         groupRepo.restoreGroup();
-      })
+      }))
       .then(() => {
         loc.push('/metric/summary');
       });

--- a/src/app/Router.js
+++ b/src/app/Router.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import { Router, Route, browserHistory, Redirect, IndexRedirect } from 'react-router';
+import { Router, Route, browserHistory, Redirect } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
 import config from 'config';
 import store from 'infra/service/store';
@@ -19,7 +19,6 @@ const prefix = config.urlPrefix;
 const RouterComp = () => (
   <Router history={history}>
     <Route path={prefix} component={App}>
-      <IndexRedirect to="welcome" />
       <Route path="welcome" component={Welcome} />
       {GroupRoute()}
       {MetricRoute()}

--- a/src/app/Welcome.js
+++ b/src/app/Welcome.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import loc from 'infra/service/location';
-import groupRepo from 'infra/repo/group';
 import Card from 'infra/component/Card';
 
 const mapStateToProps = state => ({
@@ -12,13 +11,9 @@ const mapStateToProps = state => ({
 const goTo = path => e => {
   e.preventDefault();
   loc.push(path);
-}
+};
 
 class Dashboard extends React.Component {
-
-  componentDidMount() {
-    groupRepo.restoreGroup();
-  }
 
   render() {
     const { posts } = this.props;

--- a/src/domain/layout/component/Sidebar.js
+++ b/src/domain/layout/component/Sidebar.js
@@ -30,6 +30,9 @@ class Sidebar extends Component {
       <div className="sidebar">
         <nav className="sidebar-nav">
           <ul className="nav">
+            <li className="nav-item">
+              <NavLink className="nav-link" to={loc.getUrl('/welcome')}><i className="icon-envelope-open"></i> Welcome</NavLink>
+            </li>
             
             <li className={this.activeRoute("/group")}>
               <a className="nav-link nav-dropdown-toggle" href="#" onClick={this.handleClick.bind(this)}><i className="icon-people"></i> Group</a>

--- a/src/domain/metric/container/Root.js
+++ b/src/domain/metric/container/Root.js
@@ -18,7 +18,7 @@ const mapStateToProps = state => ({
 const checkMetricAvailability = props => {
   const { loggedIn, loading, posts, comments, members } = props;
   if (!loggedIn && !loading && posts.length < 1 && comments.length < 1 && members.length < 1) loc.push('/welcome');
-}
+};
 
 class Metric extends React.Component {
 


### PR DESCRIPTION
# Summary

Auto redirect user to `/metric/summary` after page refreshed or after logged in

## Feature List

- Auto redirect to `/metric/summary`
- Move restore group data to `App` component instead on child component
- Add `Welcome` menu to sidebar